### PR TITLE
Update block-templates error message and docs

### DIFF
--- a/actions/ui-check/tests/unit/block-templates/index.js
+++ b/actions/ui-check/tests/unit/block-templates/index.js
@@ -36,7 +36,7 @@ export default ( templates ) => {
 				! emptyInnerContentFeature( block.innerContent )
 			) {
 				failures.push(
-					`There's a problem with templates in: ${ templates[ i ].fileName }.`
+					`There's a problem with the markup in ${templates[i].fileName }. There are unclosed tags or multiline blocks that are missing closing tags. Blocks are self-containing; the opening tag and the closing tag must be in the same template.`
 				); // spacer
 
 				break;

--- a/docs/ui-errors.md
+++ b/docs/ui-errors.md
@@ -82,13 +82,27 @@ This test expects to **not** find links that are not approved.
 
 Verify that the theme only includes links in the [hosts list](https://github.com/WordPress/theme-review-action/blob/trunk/actions/ui-check/tests/e2e/specs/page/unexpected-links/index.js).
 
-
 ## Block templates should be complete
 
-This tests parse block templates and block templates parts to make sure all tags have applicable closing tags and are properly formed.
+This test parses block templates and block template parts to make sure all tags have applicable closing tags and are properly formatted.
+
+Blocks are self-containing; the opening tag and the closing tag must be in the same template.
+Missing tags will cause block validation errors in the editors.
+
+Single line blocks are closed with `/-->`:
+`<!-- wp:site-title /-->`
+
+Multiline blocks are closed with `<!-- /wp:block name -->`:
+
+```html
+<!-- wp:paragraph -->
+<p>Proudly powered by <a href="https://wordpress.org/">WordPress</a>.</p>
+<!-- /wp:paragraph -->
+```
 
 ### Troubleshooting
 
 Open your template file:
+
 - Verify that all opening tags have closing tags (if applicable).
 - Verify that all tags have proper syntax.


### PR DESCRIPTION
Updates the error message and docs for the test that checks if block templates are complete.

Current:
_There's a problem with templates in: filename_

After:
_There's a problem with the markup in filename. There are unclosed tags or multiline blocks that are missing closing tags. Blocks are self-containing; the opening tag and the closing tag must be in the same template._
