### PR TITLE
Try: Frontpage display settings

### DIFF
--- a/actions/ui-check/tests/e2e/specs/page/frontpage-template/index.js
+++ b/actions/ui-check/tests/e2e/specs/page/frontpage-template/index.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import {
+	errorWithMessageOnFail,
+	getFileNameFromPath,
+} from '../../../../utils';
+
+export default async ( url ) => {
+
+	const template = await page.$eval( '#template', (el) => el.value);
+	const filename = getFileNameFromPath( template );
+
+	return errorWithMessageOnFail(
+		`${url} Frontpage template file must not be page.php`,
+		'frontpage-should-show-correct-content',
+		() => {
+			expect( filename ).not.toBe( 'page.php' );
+		},
+	);
+
+};

--- a/actions/ui-check/tests/e2e/specs/page/frontpage/index.js
+++ b/actions/ui-check/tests/e2e/specs/page/frontpage/index.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getElementPropertyAsync,
+	errorWithMessageOnFail,
+} from '../../../../utils';
+
+export default async ( url ) => {
+	// Make sure the page content appears to be appropriate for the URL.
+	const body = await page.$( 'body' );
+	const bodyClassName = await getElementPropertyAsync( body, 'className' );
+
+	return errorWithMessageOnFail(
+		`${url} does not contain the blog body class`,
+		'frontpage-should-show-correct-content',
+		() => {
+			expect( bodyClassName.split( ' ' ) ).toContain( 'blog' );
+		},
+	);
+
+};

--- a/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/html/fail.html
+++ b/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/html/fail.html
@@ -1,0 +1,6 @@
+<html>
+	<head></head>
+	<body>
+		Awesome
+	</body>
+</html>

--- a/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/html/pass.html
+++ b/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/html/pass.html
@@ -1,0 +1,6 @@
+<html>
+	<head></head>
+	<body class="blog">
+		Awesome
+	</body>
+</html>

--- a/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/frontpage/sanity/index.test.js
@@ -1,0 +1,27 @@
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import test from '../index.js';
+
+describe( 'Sanity: Blog Body Class Test', () => {
+	it( 'Page should PASS when the body class includes blog', async () => {
+		await page.goto( `file:${ path.join( __dirname, 'html/pass.html' ) }` );
+
+		expect( await test( '', 'frontpage' ) ).toBeTruthy();
+	} );
+
+	it( 'Page should FAIL when the body class does not include blog', async () => {
+		await page.goto( `file:${ path.join( __dirname, 'html/fail.html' ) }` );
+
+		expect( await test( '', 'frontpage' ) ).toBeFalsy();
+	} );
+
+	it( 'Page should FAIL when response is empty', async () => {
+		await page.goto( `file:${ path.join( __dirname, 'html/empty.html' ) }` );
+
+		expect( await test( '', 'frontpage' ) ).toBeFalsy();
+	} );
+
+} );

--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -14,6 +14,8 @@ import completeOutputTest from './complete-output';
 import pageStatusTest from './page-status';
 import jsErrorTest from './js-errors';
 import unexpectedLinksTest from './unexpected-links';
+import frontpageTest from './frontpage';
+import frontpageTemplateTest from './frontpage-template';
 
 // Some URLs like feeds aren't included in the site map.
 // TODO: should we test those separately? Not all of these tests are appropriate.
@@ -66,4 +68,30 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 		// See https://make.wordpress.org/themes/handbook/review/required/#selling-credits-and-links
 		await unexpectedLinksTest( urlPath );
 	} );
+
+} );
+
+// Some basic tests that apply only to the frontpage
+let homeurl = [ [ '/', '', 'home' ] ];
+
+describe.each( homeurl )( 'Test URL %s%s', ( url, queryString ) => {
+	let pageResponse, urlPath;
+
+	beforeAll( async () => {
+		urlPath = `"${ url }${ queryString }"`;
+		pageResponse = await goTo( url, queryString );
+
+		try {
+			urlPath = await getUrlPathWithTemplate( urlPath );
+		} catch ( ex ) {}
+	} );
+
+	it( 'Frontpage should show the correct content', async () => {
+		await frontpageTest( urlPath );
+	} );
+
+	it( 'Frontpage template should not be page.php', async () => {
+		await frontpageTemplateTest( urlPath );
+	} );
+
 } );


### PR DESCRIPTION
For https://github.com/WordPress/theme-review-action/issues/36

Tests to see if the frontpage displays the blog correctly.
- Checks if the body class on the page contains "blog".
- Checks that the template file is not page.php (Because this indicates that a static page is used).

In the test theme, I changed the frontpage to a static page by adding the following to functions.php:
```
$sample = get_page_by_title( 'Sample Page' );
update_option( 'page_on_front', $sample->ID );
update_option( 'show_on_front', 'page' );
```
I have never written tests so any feedback you can give me will help in the learning process.


