### PR TITLE
Test if theme and author URI have a valid responses

### DIFF
--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -6,7 +6,7 @@ const fetch = require( 'node-fetch' );
 /**
  * Internal dependencies
  */
-import { getFileNameFromPath, getTestUrls, goTo } from '../../../utils';
+import { getFileNameFromPath, getTestUrls, goTo, getSiteInfo } from '../../../utils';
 
 import bodyClassTest from './body-class';
 import phpErrorsTest from './php-errors';
@@ -67,3 +67,21 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 		await unexpectedLinksTest( urlPath );
 	} );
 } );
+
+// Test if theme and author URI have a valid responses
+const siteInfo = getSiteInfo();
+let theme_urls = [...siteInfo.theme_urls];
+
+describe.each( theme_urls )('Test URL %s%s', ( url ) => {
+	let pageResponse;
+
+	beforeAll(async () => {
+		pageResponse = await page.goto( url );
+	});
+
+	it( 'Page should return 200 status', async () => {
+		const status = await pageResponse.status();
+		await pageStatusTest( url, status );
+	});
+
+});

--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -72,7 +72,7 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 const siteInfo = getSiteInfo();
 let theme_urls = [...siteInfo.theme_urls];
 
-if ( theme_urls !== null ) {
+if ( theme_urls[0] ) {
 	describe.each( theme_urls )('Test URL %s%s', ( url ) => {
 		let pageResponse;
 

--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -72,16 +72,18 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 const siteInfo = getSiteInfo();
 let theme_urls = [...siteInfo.theme_urls];
 
-describe.each( theme_urls )('Test URL %s%s', ( url ) => {
-	let pageResponse;
+if ( theme_urls !== null ) {
+	describe.each( theme_urls )('Test URL %s%s', ( url ) => {
+		let pageResponse;
 
-	beforeAll(async () => {
-		pageResponse = await page.goto( url );
+		beforeAll(async () => {
+			pageResponse = await page.goto( url );
+		});
+
+		it( 'Page should return 200 status', async () => {
+			const status = await pageResponse.status();
+			await pageStatusTest( url, status );
+		});
+
 	});
-
-	it( 'Page should return 200 status', async () => {
-		const status = await pageResponse.status();
-		await pageStatusTest( url, status );
-	});
-
-});
+}

--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -73,7 +73,7 @@ const siteInfo = getSiteInfo();
 let theme_urls = [...siteInfo.theme_urls];
 
 if ( theme_urls[0] ) {
-	describe.each( theme_urls )('Test URL %s%s', ( url ) => {
+	describe.each( theme_urls )('Test URL %s', ( url ) => {
 		let pageResponse;
 
 		beforeAll(async () => {


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-review-action/issues/42

Use `pageStatusTest` to test theme and author URI fetched from _siteInfo.theme_urls_.


Tested by changing the theme and author URI of the test theme.

Resulting error report when the URL does not return 202:
```
Expected to received a 200 status for https://wordpress.org/gfdgfd. Received 404.
See: https://github.com/WordPress/theme-review-action/blob/trunk/docs/ui-errors.md#page-should-return-200-status
```