### PR TITLE
Fix php error test that misses errors in attributes.

### DIFF
--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -6,7 +6,12 @@ const fetch = require( 'node-fetch' );
 /**
  * Internal dependencies
  */
-import { getFileNameFromPath, getTestUrls, goTo, getSiteInfo } from '../../../utils';
+import {
+	getFileNameFromPath,
+	getTestUrls,
+	goTo,
+	getSiteInfo,
+} from '../../../utils';
 
 import bodyClassTest from './body-class';
 import phpErrorsTest from './php-errors';
@@ -45,7 +50,8 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 	} );
 
 	it( 'Page should not have PHP errors', async () => {
-		await phpErrorsTest( urlPath );
+		const text = await pageResponse.text();
+		await phpErrorsTest( urlPath, text );
 	} );
 
 	it( 'Page should have complete output', async () => {
@@ -68,7 +74,6 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 		// See https://make.wordpress.org/themes/handbook/review/required/#selling-credits-and-links
 		await unexpectedLinksTest( urlPath );
 	} );
-
 } );
 
 // Some basic tests that apply only to the frontpage
@@ -93,25 +98,23 @@ describe.each( homeurl )( 'Test URL %s%s', ( url, queryString ) => {
 	it( 'Frontpage template should not be page.php', async () => {
 		await frontpageTemplateTest( urlPath );
 	} );
-
 } );
 
 // Test if theme and author URI have a valid responses
 const siteInfo = getSiteInfo();
-let theme_urls = [...siteInfo.theme_urls];
+let theme_urls = [ ...siteInfo.theme_urls ];
 
-if ( theme_urls[0] ) {
-	describe.each( theme_urls )('Test URL %s', ( url ) => {
+if ( theme_urls[ 0 ] ) {
+	describe.each( theme_urls )( 'Test URL %s', ( url ) => {
 		let pageResponse;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			pageResponse = await page.goto( url );
-		});
+		} );
 
 		it( 'Page should return 200 status', async () => {
 			const status = await pageResponse.status();
 			await pageStatusTest( url, status );
-		});
-
-	});
+		} );
+	} );
 }

--- a/actions/ui-check/tests/e2e/specs/page/php-errors/index.js
+++ b/actions/ui-check/tests/e2e/specs/page/php-errors/index.js
@@ -2,19 +2,19 @@
  * Internal dependencies
  */
 import {
-	errorWithMessageOnFail,
-	getPageError,
-	removeLocalPathRefs,
+    errorWithMessageOnFail,
+    getErrorFromPage,
+    removeLocalPathRefs,
 } from '../../../../utils';
 
-export default async ( url ) => {
-	const pageError = await getPageError();
+export default async(url, text) => {
+    const pageError = await getErrorFromPage(text);
 
-	return errorWithMessageOnFail(
-		`${ url } contains PHP errors: ${ removeLocalPathRefs( pageError ) }`,
-		'page-should-not-have-php-errors',
-		() => {
-			expect( pageError ).toBe( null );
-		}
-	);
+    return errorWithMessageOnFail(
+        `${ url } contains PHP errors: ${ removeLocalPathRefs( pageError ) }`,
+        'page-should-not-have-php-errors',
+        () => {
+            expect(pageError).toBe(null);
+        }
+    );
 };

--- a/actions/ui-check/tests/e2e/specs/page/php-errors/sanity/html/fail-attribute.html
+++ b/actions/ui-check/tests/e2e/specs/page/php-errors/sanity/html/fail-attribute.html
@@ -1,0 +1,15 @@
+<div class="col-lg-9 text-right">
+    <nav id="site-navigation" class="main-navigation" role="navigation" aria-label="
+Fatal error: Uncaught Error: Call to undefined function esc_attr_() in /var/www/html/wp-content/themes/test-theme/nav/header-nav.php:93
+Stack trace:
+#0 /var/www/html/wp-includes/template.php(772): require()
+#1 /var/www/html/wp-includes/template.php(716): load_template('/var/www/html/w...', false, Array)
+#2 /var/www/html/wp-includes/general-template.php(204): locate_template(Array, true, false, Array)
+#3 /var/www/html/wp-content/themes/test-theme/header.php(35): get_template_part('nav/header-nav')
+#4 /var/www/html/wp-includes/template.php(770): require_once('/var/www/html/w...')
+#5 /var/www/html/wp-includes/template.php(716): load_template('/var/www/html/w...', true, Array)
+#6 /var/www/html/wp-includes/general-template.php(48): locate_template(Array, true, true, Array)
+#7 /var/www/html/wp-content/themes/test-theme/index.php(14): get_header()
+#8 /var/www/html/wp-includes/template-loader.php(106): include('/var/www/html/w...')
+#9 /var/www/html/wp-blog-header.php(19): require_once('/var/www/html/w...')
+#10 /var/www/html/index in /var/www/html/wp-content/themes/test-theme/nav/header-nav.php on line 93

--- a/actions/ui-check/tests/e2e/specs/page/php-errors/sanity/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/php-errors/sanity/index.test.js
@@ -10,22 +10,41 @@ import test from '../index.js';
 
 describe( 'Sanity: PHP Errors', () => {
 	it( 'Page should PASS when there is not php error present', async () => {
-		await page.goto( `file:${ path.join( __dirname, 'html/pass.html' ) }` );
+		const url = 'html/pass.html';
+		const response = await page.goto(
+			`file:${ path.join( __dirname, url ) }`
+		);
 
-		expect( await test() ).toBeTruthy();
+		const content = await response.text();
+		expect( await test( url, content ) ).toBeTruthy();
 	} );
 
 	it( 'Page should FAIL when there is a php error present', async () => {
-		await page.goto( `file:${ path.join( __dirname, 'html/fail.html' ) }` );
+		const url = 'html/fail.html';
+		const response = await page.goto(
+			`file:${ path.join( __dirname, url ) }`
+		);
 
-		expect( await test() ).toBeFalsy();
+		const content = await response.text();
+		expect( await test( url, content ) ).toBeFalsy();
 	} );
 
 	it( 'Page should FAIL when there is a php present on multiple lines', async () => {
-		await page.goto(
-			`file:${ path.join( __dirname, 'html/fail-multiline.html' ) }`
+		const url = 'html/fail-multiline.html';
+		const response = await page.goto(
+			`file:${ path.join( __dirname, url ) }`
 		);
 
-		expect( await test() ).toBeFalsy();
+		const content = await response.text();
+		expect( await test( url, content ) ).toBeFalsy();
+	} );
+
+	it( 'Page should FAIL when there is a php error present in an attribute', async () => {
+		const url = 'html/fail-attribute.html';
+		const response = await page.goto(
+			`file:${ path.join( __dirname, url ) }`
+		);
+		const content = await response.text();
+		expect( await test( url, content ) ).toBeFalsy();
 	} );
 } );

--- a/actions/ui-check/tests/utils/helpers.js
+++ b/actions/ui-check/tests/utils/helpers.js
@@ -17,8 +17,7 @@ const REGEXP_PHP_ERROR = /(<b>)?(Fatal error|Recoverable fatal error|Warning|Par
  * @return {Promise<?string>} Promise resolving to a string or null, depending
  *                            whether a page error is present.
  */
-export async function getPageError() {
-	const content = await page.content();
+export async function getErrorFromPage( content ) {
 	const match = content.match( REGEXP_PHP_ERROR );
 	return match ? match[ 0 ] : null;
 }


### PR DESCRIPTION
Fixes #63.

The errors were not being caught because `page.content` returns a valid HTML document. Getting the response text displays the issue properly and the regex catches it.