### PR TITLE
Fix status check

### DIFF
--- a/actions/ui-check/tests/e2e/specs/page/index.test.js
+++ b/actions/ui-check/tests/e2e/specs/page/index.test.js
@@ -60,7 +60,7 @@ describe.each( urls )( 'Test URL %s%s', ( url, queryString, bodyClass ) => {
 		await completeOutputTest( urlPath, text );
 	} );
 
-	it( 'Page should return 200 status', async () => {
+	it( 'Page should return 200 or 304 status', async () => {
 		const status = await pageResponse.status();
 
 		await pageStatusTest( urlPath, status );
@@ -112,7 +112,7 @@ if ( theme_urls[ 0 ] ) {
 			pageResponse = await page.goto( url );
 		} );
 
-		it( 'Page should return 200 status', async () => {
+		it( 'Page should return 200 or 304 status', async () => {
 			const status = await pageResponse.status();
 			await pageStatusTest( url, status );
 		} );

--- a/actions/ui-check/tests/e2e/specs/page/page-status/index.js
+++ b/actions/ui-check/tests/e2e/specs/page/page-status/index.js
@@ -8,7 +8,7 @@ export default async ( url, status ) => {
 		`Expected to received a 200 status for ${ url }. Received ${ status }.`,
 		'page-should-return-200-status',
 		() => {
-			expect( status ).toBe( 200 );
+			expect( status ).toMatch( /^(200|304)$/ );
 		}
 	);
 };


### PR DESCRIPTION
It failed, if page returns 304 Not Modified code. This happened on my side because Theme URI and Author URI contains an identical URL and the second call returned 304 instead of 200. Here is a fix.