### PR TITLE
Switch from old set-output syntax to newer file method

### DIFF
--- a/bin/github.js
+++ b/bin/github.js
@@ -7,7 +7,7 @@ const ACTIONS_PATH = `${process.env.GITHUB_ACTION_PATH}/actions`;
 
 const setConfiguration = (key, value) => {
 	console.log(`Setting output for ${key}.`);
-	console.log(`::set-output name=${key}::${value}`);
+	fs.appendFileSync( process.env.GITHUB_OUTPUT, `${key}=${value}\n` );
 };
 
 /**


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This is untested, but I think it'll work.. 